### PR TITLE
Added min level for wild boar and bison pelts

### DIFF
--- a/wwwroot/data/items.json
+++ b/wwwroot/data/items.json
@@ -246,8 +246,8 @@
     "id": 17,
     "value": 90,
     "icon": "Pelt",
-    "isTannable": true,
-    "requiredLevel": 1
+    "requiredLevel": 1,
+    "isTannable": true
   },
   {
     "itemName": "Deer Meat",
@@ -1063,6 +1063,7 @@
     "itemDescription": "The pelt of a bison.",
     "id": 85,
     "icon": "Pelt",
+    "requiredLevel": 91,
     "isTannable": true,
     "value": 700
   },
@@ -1080,6 +1081,7 @@
     "itemDescription": "The pelt of a wild boar.",
     "id": 87,
     "value": 325,
+    "requiredLevel": 43,
     "isTannable": true,
     "icon": "Pelt"
   },


### PR DESCRIPTION
It seems the minimum leatherworking levels were missing for a couple of the pelts.  (I just noticed that I am now a contributor (thanks!), but I didn't want to assume I could just post the changes to the live game.  Should I continue using pull requests or should I just update the master branch if I'm confident in my change?) 